### PR TITLE
Add multi-step LLM pipeline, structured logging, and provider support for citation auditing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to **softwarecitationauditor** will be documented in this file.
+
+---
+
+## [Unreleased]
+
+### Added
+- Multi-step prompt execution from `prompt.in` using LLMs (OpenAI, Claude, Gemini, Ollama)
+- Step-by-step reasoning across:
+  - Step 1: Extract software tools
+  - Step 2: Check citations
+  - Step 3: Suggest BibTeX for uncited tools
+- Rich-based table output for better terminal display of results
+- Structured logging (log level: DEBUG, INFO, WARNING)
+- Colored CLI output for status and results
+- Test coverage for CLI, OpenAI checker, and prompt parsing
+- CLI refactored to use `typer` for better UX
+- Support for local and remote PDF input
+- Custom prompt support via `prompt.in` (multi-step and templated)
+- Optional saving of reports (`--save-report`)
+- Automatic directory management (`downloads/`, `reports/`)
+- Support for OpenAI, Claude, Gemini, and Ollama providers
+
+### Changed
+- Converted prompts to enforce **strict JSON-only** responses
+- Enhanced PDF extraction using `PyMuPDF` page-wise processing
+- Refactored OpenAI checker to support sequential step querying
+- Improved progress bar to reflect step-by-step processing
+- Enhanced test mocking and error handling during JSON parse
+
+### Fixed
+- Robust error reporting for invalid JSON response
+- Fixed bugs in CLI argument handling and optional input file
+- Resolved CLI install issues by correcting package discovery
+
+---
+
+## [0.1.0] – Initial release
+
+- Basic functionality to extract and analyze software citations in research papers

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-
 # softwarecitationauditor
 
-**softwarecitationauditor** is a Python command-line tool to extract software mentions from research papers (PDFs) and check whether they are properly cited, using the OpenAI API — with **experimental support** for Claude and Gemini.
+**softwarecitationauditor** is a Python command-line tool to extract software mentions from research papers (PDFs) and check whether they are properly cited, using structured LLM queries — supporting OpenAI, Claude, Gemini, and Ollama.
 
 ---
 
@@ -57,7 +56,7 @@ https://arxiv.org/pdf/2305.67890.pdf
 
 ---
 
-## ⚡ Experimental: Using Other Models
+## 🤖 Model Support
 
 You can switch providers and models using:
 
@@ -97,10 +96,18 @@ You can switch providers and models using:
 
 ## ✍️ Custom Prompt
 
-Edit the `prompt.in` file in the `softwarecitationauditor` folder:
+The tool uses a `prompt.in` file with clearly defined multi-step prompts. Each step must return only a valid JSON object, with no markdown or extra explanation.
+
+Each step is separated by:
+```
+--- step N ---
+```
+
+Example:
 
 ```
-Given the following paper body and bibliography, extract the software tools used in the paper and check if they are properly cited.
+--- step 1 ---
+Given the following paper body and bibliography, identify all software tools mentioned in the body. Return only a JSON list of software tool names.
 
 Body:
 {{BODY_TEXT}}
@@ -108,8 +115,20 @@ Body:
 Bibliography:
 {{BIBLIOGRAPHY_TEXT}}
 
-Return the result as a Markdown table with columns: Software, Mentioned, Properly Cited.
+Return only a valid JSON array like: ["Tool1", "Tool2", ...]
+Do not include markdown formatting or explanations.
+
+--- step 2 ---
+For each software tool identified in Step 1, check if it appears in the bibliography. Return a JSON list of objects with fields: name, cited (true/false), and reason.
+
+Use the same Body and Bibliography as Step 1.
+Return only a valid JSON list of objects.
+
+--- step 3 ---
+For all software tools where cited is false, generate a suggested BibTeX entry. Return a JSON list of objects with name and bibtex fields.
 ```
+
+This format ensures predictable parsing and reliable multi-step model execution.
 
 ---
 
@@ -117,6 +136,17 @@ Return the result as a Markdown table with columns: Software, Mentioned, Properl
 
 - Downloaded PDFs → `downloads/` folder
 - Reports → `reports/` folder (`<pdf-id>_report.md`)
+
+---
+
+### 🧠 Multi-Step Reasoning
+
+This tool breaks down the analysis into multiple LLM steps:
+- Step 1: Identify software tools mentioned
+- Step 2: Check if each tool is cited in the bibliography
+- Step 3: Suggest missing citations for uncited tools
+
+Each step is designed to produce clean structured JSON output and is handled sequentially via the selected model provider.
 
 ---
 

--- a/softwarecitationauditor/main.py
+++ b/softwarecitationauditor/main.py
@@ -1,17 +1,18 @@
 import sys
 from pathlib import Path
 import typer
-from tqdm import tqdm
+from colorama import Fore, Style, init as colorama_init
+colorama_init()
 from .downloader import download_pdf
 from .extractor import extract_text_from_pdf
 from .openai_checker import extract_and_check_software
 
 app = typer.Typer(help="Audit software mentions and citations in research papers.")
 
-def process_paper(pdf_input, provider, model):
+def process_paper(pdf_input, provider, model, save_report: bool = True):
     pdf_file = download_pdf(pdf_input)
     body_text, bibliography = extract_text_from_pdf(pdf_file)
-    extract_and_check_software(body_text, bibliography, pdf_file, provider, model)
+    extract_and_check_software(body_text, bibliography, pdf_file, provider, model, save_report=save_report)
     Path(pdf_file).unlink()  # Clean up the downloaded PDF
     
 @app.command()
@@ -19,10 +20,11 @@ def audit(
     pdf: str = typer.Argument(None, help="Single PDF path or URL."),
     input_file: str = typer.Option(None, "--input-file", "-i", help="Path to file with list of PDFs."),
     provider: str = typer.Option("openai", "--provider", "-p", help="LLM provider", show_default=True, case_sensitive=False),
-    model: str = typer.Option("gpt-3.5-turbo", "--model", "-m", help="LLM model to use", show_default=True)
+    model: str = typer.Option("gpt-3.5-turbo", "--model", "-m", help="LLM model to use", show_default=True),
+    save_report: bool = typer.Option(False, "--save-report", help="Save the final audit report to disk")
 ):
     if not pdf and not input_file:
-        typer.echo("❌ You must provide either a PDF path or --input-file")
+        typer.echo(f"{Fore.RED}❌ You must provide either a PDF path or --input-file{Style.RESET_ALL}")
         raise typer.Exit(code=1)
 
     inputs = []
@@ -32,9 +34,9 @@ def audit(
     elif pdf:
         inputs = [pdf]
 
-    for pdf_input in tqdm(inputs, desc="Processing PDFs", unit="pdf"):
-        typer.echo(f"\n📄 Processing: {pdf_input}")
-        process_paper(pdf_input, provider, model)
+    for i, pdf_input in enumerate(inputs, start=1):
+        typer.echo(f"{Fore.YELLOW}\n📄 [{i}/{len(inputs)}] Processing: {pdf_input}{Style.RESET_ALL}")
+        process_paper(pdf_input, provider, model, save_report)
 
 def cli():
     app()

--- a/softwarecitationauditor/openai_checker.py
+++ b/softwarecitationauditor/openai_checker.py
@@ -1,5 +1,18 @@
 import os
+import json
+import logging
 from openai import OpenAI
+from colorama import Fore, Style, init as colorama_init
+from rich.console import Console
+from rich.table import Table
+colorama_init()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler()]
+)
+logger = logging.getLogger(__name__)
 
 def load_prompt_template():
     package_dir = os.path.dirname(__file__)
@@ -9,58 +22,102 @@ def load_prompt_template():
     with open(prompt_path, "r") as f:
         return f.read()
 
-def extract_and_check_software(body_text, bibliography_text, pdf_filename, provider, model, client=None):
+console = Console()
+
+def print_json_as_table(json_data, step_number):
+    if isinstance(json_data, dict):
+        table = Table(title=f"Step {step_number} - JSON Output")
+        table.add_column("Key")
+        table.add_column("Value")
+        for key, value in json_data.items():
+            value_str = json.dumps(value, indent=2) if isinstance(value, (dict, list)) else str(value)
+            table.add_row(str(key), value_str)
+        console.print(table)
+    elif isinstance(json_data, list) and all(isinstance(row, dict) for row in json_data):
+        keys = sorted(set(k for d in json_data for k in d.keys()))
+        table = Table(title=f"Step {step_number} - JSON Output")
+        for key in keys:
+            table.add_column(str(key))
+        for item in json_data:
+            table.add_row(*(str(item.get(k, "")) for k in keys))
+        console.print(table)
+    else:
+        logger.info("✅ JSON content (non-tabular):")
+        logger.info(json.dumps(json_data, indent=2))
+
+def extract_and_check_software(body_text, bibliography_text, pdf_filename, provider, model, save_report=False, client=None):
     os.makedirs("reports", exist_ok=True)
     base_name = os.path.splitext(os.path.basename(pdf_filename))[0]
     report_name = os.path.join("reports", f"{base_name}_report.md")
 
     prompt_template = load_prompt_template()
-    prompt = prompt_template.replace("{{BODY_TEXT}}", body_text) \
-                            .replace("{{BIBLIOGRAPHY_TEXT}}", bibliography_text)
+    templates = prompt_template.split("---SPLIT STEP---")
 
+    history = []
     answer = ""
-    if provider == "openai":
-        client = client or OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-        response = client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": prompt}],
-        )
-        answer = response.choices[0].message.content
-    elif provider == "claude":
-        import anthropic
-        client = client or anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
-        response = client.messages.create(
-            model=model,
-            max_tokens=4000,
-            messages=[{"role": "user", "content": prompt}]
-        )
-        answer = response.content[0].text
-    elif provider == "gemini":
-        import google.generativeai as genai
-        genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
-        client = client or genai.GenerativeModel(model)
-        response = client.generate_content(prompt)
-        answer = response.text
-    elif provider == "ollama":
-        import ollama
 
-        client = client or ollama
-        model = model or "llama3"
+    for step_number, template in enumerate(templates, start=1):
+        # Replace placeholders
+        formatted_prompt = template.strip() \
+            .replace("{{BODY_TEXT}}", body_text) \
+            .replace("{{BIBLIOGRAPHY_TEXT}}", bibliography_text)
+        for i, result in enumerate(history, start=1):
+            formatted_prompt = formatted_prompt.replace(f"{{{{STEP{i}_RESULT}}}}", result)
 
-        try:
-            response = client.chat(
+        logger.info(f"🚀 Step {step_number}/{len(templates)}: Executing prompt step...")
+
+        if provider == "openai":
+            client = client or OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+            response = client.chat.completions.create(
                 model=model,
-                messages=[
-                    {"role": "user", "content": prompt}
-                ]
+                messages=[{"role": "user", "content": formatted_prompt}],
             )
-            answer = response["message"]["content"]
-        except Exception as e:
-            raise RuntimeError(f"Ollama REST call failed: {e}")
-    else:
-        raise ValueError(f"Unknown provider: {provider}")
+            result = response.choices[0].message.content.strip()
+        elif provider == "claude":
+            import anthropic
+            client = client or anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+            response = client.messages.create(
+                model=model,
+                max_tokens=4000,
+                messages=[{"role": "user", "content": formatted_prompt}]
+            )
+            result = response.content[0].text.strip()
+        elif provider == "gemini":
+            import google.generativeai as genai
+            genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
+            client = client or genai.GenerativeModel(model)
+            response = client.generate_content(formatted_prompt)
+            result = response.text.strip()
+        elif provider == "ollama":
+            import ollama
+            client = client or ollama
+            model = model or "llama3"
+            try:
+                response = client.chat(
+                    model=model,
+                    messages=[{"role": "user", "content": formatted_prompt}]
+                )
+                result = response["message"]["content"].strip()
+            except Exception as e:
+                raise RuntimeError(f"Ollama REST call failed: {e}")
+        else:
+            raise ValueError(f"Unknown provider: {provider}")
 
-    with open(report_name, "w") as f:
-        print(answer)
-        f.write(answer)
-    print(f"✅ Report generated: {report_name}")
+        logger.debug(f"Raw result for step {step_number}:\n{result}")
+
+        history.append(result)
+        try:
+            parsed_json = json.loads(result)
+            logger.info(f"✅ Step {step_number} completed.")
+            print_json_as_table(parsed_json, step_number)
+        except json.JSONDecodeError as e:
+            logger.warning(f"Step {step_number} result is not valid JSON. Showing preview instead.")
+            logger.debug(f"JSON decode error: {e}")
+            logger.warning(f"✅ Step {step_number} completed. Output (raw text preview):\n{result[:200]}{'...' if len(result) > 200 else ''}")
+
+    answer = history[-1]
+
+    if save_report:
+        with open(report_name, "w") as f:
+            f.write(answer)
+        logger.info(f"✅ Report generated: {report_name}")

--- a/softwarecitationauditor/prompt.in
+++ b/softwarecitationauditor/prompt.in
@@ -1,2 +1,53 @@
+### Step 1: Extract Software Mentions
+
+Below is the body of an academic paper. Extract all mentions of software tools, libraries, packages, or platforms that are likely used in the research.
+
 {{BODY_TEXT}}
-Can you extract which softwares are used in this paper and if they are properly cited? Return the result only as a Markdown table with columns: Software, Citation Provided?, Reference ID(s)
+
+You must return only a valid JSON object with no explanation, preamble, or formatting outside the JSON. Do not include markdown formatting (like triple backticks), introductory phrases, or explanations. Just output the JSON object directly. The JSON must be parsable by a standard JSON parser.
+{
+  "software_mentions": ["ToolA", "LibraryB", "PlatformC"]
+}
+
+---SPLIT STEP---
+
+### Step 2: Analyze Citations
+
+Here is the bibliography or references section of the paper:
+
+{{BIBLIOGRAPHY_TEXT}}
+
+Given the following list of software mentioned in the paper:
+
+{{STEP1_RESULT}}
+
+For each software, check whether a citation is provided in the bibliography. You must return only a valid JSON object with no explanation, preamble, or formatting outside the JSON. Do not include markdown formatting (like triple backticks), introductory phrases, or explanations. Just output the JSON object directly. The JSON must be parsable by a standard JSON parser.
+{
+  "citation_analysis": [
+    {
+      "software": "ToolA",
+      "cited": true,
+      "reference_ids": ["[2]", "[5]"]
+    },
+    {
+      "software": "LibraryB",
+      "cited": false,
+      "reference_ids": []
+    }
+  ]
+}
+
+---SPLIT STEP---
+
+### Step 3: Suggest Missing Citations
+
+Based on the citation analysis:
+
+{{STEP2_RESULT}}
+
+Identify all software entries where a citation was not provided. For each of these, suggest a proper citation that could be added to the paper. Provide the citation as a BibTeX entry. You must return only a valid JSON object with no explanation, preamble, or formatting outside the JSON. Do not include markdown formatting (like triple backticks), introductory phrases, or explanations. Just output the JSON object directly. The JSON must be parsable by a standard JSON parser.
+{
+  "suggested_citations": {
+    "LibraryB": "@misc{libraryb2023, title={LibraryB: An Example Tool}, author={Author, A.}, year={2023}, url={https://example.com/libraryb}}"
+  }
+}


### PR DESCRIPTION
Features Added
	•	Multi-step prompt execution from prompt.in, allowing sequential LLM querying:
	•	Step 1: Extract software tools, Step 2: Validate citations, Step 3: Suggest BibTeX for missing citations
	•	Structured logging via rich.logging with improved visibility for CLI users
	•	Table-based display of step outputs using rich.table for clarity
	•	Colored status messages and debug prints
	•	Optional report saving (--save-report)

Prompt Handling
	•	Prompts read from prompt.in, now using a clean step delimiter format (--- step N ---)
	•	Each step returns strict JSON only — no markdown or preamble
	•	Robust error handling for malformed JSON or step failures